### PR TITLE
Rename `thread` import into `_thread`

### DIFF
--- a/irccloud.py
+++ b/irccloud.py
@@ -5,7 +5,7 @@ import json
 import requests
 import sys
 import time
-import thread
+import _thread
  
  
 delay = 30


### PR DESCRIPTION
This module has been renamed in python 3+
